### PR TITLE
:bug: Fix: Like, Schedule 모델 migrate 에러 수정 ( #37 )

### DIFF
--- a/BE/likes/models.py
+++ b/BE/likes/models.py
@@ -4,7 +4,7 @@ from posts.models import CommunityPost
 from recruits.models import RecruitmentPost
 
 
-class Notification(models.Model):
+class Like(models.Model):
     '''
     좋아요 모델
 

--- a/BE/schedules/models.py
+++ b/BE/schedules/models.py
@@ -2,9 +2,9 @@ from django.db import models
 from teams.models import Team
 
 
-class RecruitmentPost(models.Model):
+class Schedules(models.Model):
     '''
-    모집 게시글 모델
+    일정 모델
 
     Attributes:
         team (ForeignKey): Team 모델과의 1:1 관계


### PR DESCRIPTION
## 원인
Like의 model 이름이 Notification으로,
Schedule model의 이름이 RecruitPost로 설정되어 참조 오류 발생

## 수정
해당 기능에 맞게 model 명 수정

## 결과
manage.py makemigrations를 했을 때 fields.E304오류가 반환 되던 것 해결