### PR TITLE
:sparkles: Feat: 모임 앱 API구현 ( # 57 )

### DIFF
--- a/BE/schedules/admin.py
+++ b/BE/schedules/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from .models import Schedule
 
-# Register your models here.
+admin.site.register(Schedule)

--- a/BE/schedules/models.py
+++ b/BE/schedules/models.py
@@ -11,42 +11,23 @@ class Schedule(models.Model):
         frequency : 매일, 매주, 매월과 같은 반복성을 설정합니다. 특정일만 진행할 모임일 경우 '주기없음'으로 설정합니다.
         day : frequency를 '매주' 혹은 '매달'로 설정했을 때, 'x요일'을 지정할 때 사용합니다.
         week : frequency를 '매달'로 설정했을 때, 'n번째' 주를 특정하기 위해 사용합니다.
-        date : frequency가 '주기 없음'일 때 특정일을 일정으로 지정합니다.
     
     Detail:
-        day를 월요일, 수요일로 다중지정했을 시 DB에는 "월요일, 수요일"로 저장됩니다.
+        FE에서 day, week를 다중값으로 받았을 때 list형태로 data를 주고받습니다.
+        list로 날아온 data를 변형하여 DB에는 "월요일, 수요일"로 저장합니다.
     '''
     FREQUENCY_CHOICES = [
-        ('주기없음', '주기없음'),
         ('매일', '매일'),
         ('매주', '매주'),
         ('매월', '매월'),
     ]
 
-    DAY_CHOICES = [
-        ('월요일', '월요일'),
-        ('화요일', '화요일'),
-        ('수요일', '수요일'),
-        ('목요일', '목요일'),
-        ('금요일', '금요일'),
-        ('토요일', '토요일'),
-        ('일요일', '일요일'),
-    ]
-    WEEK_CHOICES = [
-        (1, '첫째 주'),
-        (2, '둘째 주'),
-        (3, '셋째 주'),
-        (4, '넷째 주'),
-        (5, '다섯째 주'),
-    ]
-
-    team = models.ForeignKey(Team, on_delete=models.CASCADE)
+    team = models.OneToOneField(Team, on_delete=models.CASCADE, related_name='schedule')
     frequency = models.CharField(max_length=10, choices=FREQUENCY_CHOICES)
-    day = models.CharField(max_length=10, choices=DAY_CHOICES, null=True, blank=True)
-    week = models.CharField(max_length=10, choices=WEEK_CHOICES, null=True, blank=True)
-    date = models.DateField(null=True, blank=True)
+    day = models.CharField(max_length=100, null=True, blank=True)
+    week = models.CharField(max_length=100, null=True, blank=True)
     start_time = models.TimeField(null=True, blank=True)
     end_time = models.TimeField(null=True, blank=True)
 
     def __str__(self):
-        return f'모임({self.team})의 일정'
+        return f'{self.team}의 일정'

--- a/BE/schedules/urls.py
+++ b/BE/schedules/urls.py
@@ -1,0 +1,4 @@
+from django.urls import path
+
+urlpatterns = [
+]

--- a/BE/teams/admin.py
+++ b/BE/teams/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
+from .models import Team, TeamMember
 
-# Register your models here.
+admin.site.register(Team)
+admin.site.register(TeamMember)

--- a/BE/teams/models.py
+++ b/BE/teams/models.py
@@ -1,10 +1,25 @@
 from django.db import models
+from django.contrib.auth import get_user_model
 
 def team_thumbnail_path(instance, filename):
     return f'team_thumbnails/team_{instance.id}/{filename}'
 
 
 class Team(models.Model):
+    '''
+    모임 모델
+
+    Attributes:
+        category : CATEGORY_CHOICES의 선택지 중 택1
+        is_closed : 모임의 모집 여부(False일 경우 모집 중)
+        location : 모임이 오프라인에서 진행될 때 입력할 주소
+        member : User모델과의 N:M관계 (매핑테이블 : TeamMember)
+
+    Detail:
+        모집 게시글 작성 시 같이 생성됩니다.
+        location, introduce, image는 모집게시글 작성 후 팀 정보 수정에서 입력합니다.
+        current_attendance == max_attendance일 경우 is_closed = false 변경 불가합니다.
+    '''
     CATEGORY_CHOICES = [
         ('독서모임', '독서모임'),
         ('합평모임', '합평모임'),
@@ -18,6 +33,28 @@ class Team(models.Model):
     current_attendance=models.IntegerField(default=0)
     introduce = models.TextField(null=True, blank=True)
     image = models.ImageField(upload_to=team_thumbnail_path, null=True, blank=True)
+    member = models.ManyToManyField(get_user_model(), through='TeamMember', related_name='teams')
 
     def __str__(self):
         return self.name
+
+
+class TeamMember(models.Model):
+    '''
+    User-Team 모델
+
+    Attributes:
+        is_leader : 해당 유저가 모임의 리더인지 구성원인지 설정
+        is_approved : True일경우 모임의 구성원으로 활동 가능
+    
+    Detail:
+        유저가 모집 게시글에서 참가 신청을 할 경우 TeamMember에 데이터가 추가됩니다.
+        리더가 신청을 승인할 때 해당 유저의 is_approved의 값이 True가 되며, 모임의 구성원으로 인정됩니다.
+    '''
+    user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
+    team = models.ForeignKey(Team, on_delete=models.CASCADE)
+    is_leader = models.BooleanField(default=False)
+    is_approved = models.BooleanField(default=False)
+
+    def __str__(self):
+        return f'{self.team} 모임의 구성원 {self.user}'

--- a/BE/teams/permissions.py
+++ b/BE/teams/permissions.py
@@ -1,0 +1,26 @@
+from teams.models import TeamMember
+from rest_framework import permissions
+from rest_framework.exceptions import PermissionDenied
+
+class IsLeaderOrReadOnly(permissions.BasePermission):
+    """
+    리더 권한 설정
+    """
+
+    def has_permission(self, request, view):
+        # 모든 사용자에 대한 읽기 권한 허용
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # PUT 및 DELETE 메서드에 대한 권한
+        team_id = view.kwargs.get('team_id')
+        leader = TeamMember.objects.filter(team_id=team_id, user=request.user.id, is_leader=True).exists()
+        return request.user.is_authenticated and leader
+    
+    def has_object_permission(self, request, view, obj):
+        if request.method in ['PUT', 'DELETE']:
+            team_id = view.kwargs.get('team_id')
+            leader = TeamMember.objects.filter(team_id=team_id, user=request.user.id, is_leader=True).exists()
+            if not leader:
+                raise PermissionDenied('모임의 리더 권한이 필요합니다.')
+        return True

--- a/BE/teams/serializers.py
+++ b/BE/teams/serializers.py
@@ -1,0 +1,65 @@
+from rest_framework import serializers
+from schedules.models import Schedule
+from django.contrib.auth import get_user_model
+from .models import Team, TeamMember
+
+class TeamSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Team
+        fields = ['name', 'category', 'is_closed', 'location', 'max_attendance', 'current_attendance', 'introduce', 'image', 'member']
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = get_user_model()
+        fields = ['id', 'email', 'nickname', 'profile_image']
+
+
+class TeamMemberSerializer(serializers.ModelSerializer):
+    user = UserSerializer()
+
+    class Meta:
+        model = TeamMember
+        fields = ['user', 'is_leader', 'is_approved']
+
+
+class TeamMemberChangeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TeamMember
+        fields = ['team', 'user', 'is_leader']
+
+class ScheduleSerializer(serializers.ModelSerializer):
+    day = serializers.ListField(child=serializers.CharField(), allow_empty=True)
+    week = serializers.ListField(child=serializers.CharField(), allow_empty=True)
+
+    class Meta:
+        model = Schedule
+        fields = ['frequency', 'day', 'week', 'start_time', 'end_time']
+
+class TeamDetailSerializer(serializers.ModelSerializer):
+    schedule = ScheduleSerializer()
+
+    class Meta:
+        model = Team
+        fields = ['name', 'category', 'is_closed', 'location', 'max_attendance', 'current_attendance', 'introduce', 'image', 'schedule']
+    
+    def update(self, instance, validated_data):
+        schedule_data = validated_data.pop('schedule', {})
+        schedule_instance = instance.schedule
+
+        # schedule 데이터 업데이트
+        for key, value in schedule_data.items():
+            setattr(schedule_instance, key, value)
+
+        # 유효성 검사를 통한 데이터 저장
+        schedule_serializer = ScheduleSerializer(instance=schedule_instance, data=schedule_data)
+        schedule_serializer.is_valid(raise_exception=True)
+        schedule_serializer.save()
+
+        # Team 모델의 나머지 필드 업데이트
+        for key, value in validated_data.items():
+            setattr(instance, key, value)
+            
+        instance.save()
+
+        return instance

--- a/BE/teams/urls.py
+++ b/BE/teams/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+from .views import TeamListView, TeamDetailView, TeamJoinView, TeamLeaveView, TeamKickView, TeamLeaderChangeView, TeamMembersView
+
+urlpatterns = [
+    path('', TeamListView.as_view(), name='team-list'),
+    path('<int:pk>/', TeamDetailView.as_view(), name='team-detail'),
+    path('<int:pk>/join/', TeamJoinView.as_view(), name='team-join'),
+    path('<int:pk>/leave/', TeamLeaveView.as_view(), name='team-leave'),
+    path('<int:pk>/kick/', TeamKickView.as_view(), name='team-kick'),
+    path('<int:pk>/leader/', TeamLeaderChangeView.as_view(), name='team-leader'),
+    path('<int:pk>/members/', TeamMembersView.as_view(), name='team-members'),
+]

--- a/BE/teams/views.py
+++ b/BE/teams/views.py
@@ -1,3 +1,124 @@
-from django.shortcuts import render
+from rest_framework.generics import get_object_or_404
+from rest_framework import generics
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.response import Response
+from rest_framework import status
+from .models import Team, TeamMember
+from .serializers import TeamSerializer, TeamMemberSerializer, TeamMemberChangeSerializer, TeamDetailSerializer
+from .permissions import IsLeaderOrReadOnly
 
-# Create your views here.
+
+class TeamListView(generics.ListAPIView):
+    '''
+    모임의 목록을 조회하는 View
+    로그인 권한 필요
+    '''
+    queryset = Team.objects.all()
+    serializer_class = TeamSerializer
+    permission_classes = [AllowAny]
+    # permission_classes = [IsAuthenticated]
+
+
+class TeamDetailView(generics.RetrieveUpdateDestroyAPIView):
+    '''
+    모임의 상세 정보를 조회, 업데이트, 삭제하는 View
+    로그인 권한 필요, 수정/삭제는 리더 권한 필요
+    '''
+    queryset = Team.objects.all()
+    serializer_class = TeamDetailSerializer
+    permission_classes = [AllowAny]
+    # permission_classes = [IsAuthenticated, IsLeaderOrReadOnly]
+
+
+class TeamJoinView(generics.UpdateAPIView):
+    '''
+    모임 가입 신청한 유저를 승인하기 위한 View
+    로그인 권한, 리더 권한 필요
+    request body : user_id (승인 대상의 user_id)
+    '''
+    queryset = TeamMember.objects.all()
+    permission_classes = [IsAuthenticated, IsLeaderOrReadOnly]
+
+    def update(self, request, *args, **kwargs):
+        user_id = request.data.get('user_id')
+        team_member = get_object_or_404(
+            TeamMember, team_id=self.kwargs.get('team_id'), user_id=user_id, is_leader=True, user=request.user
+        )
+        team_member.is_approved = True
+        team_member.save()
+        return Response({'detail': '참가신청 승인 완료되었습니다.'}, status=status.HTTP_200_OK)
+    
+
+class TeamLeaveView(generics.DestroyAPIView):
+    '''
+    모임 탈퇴를 위한 View
+    로그인 권한 필요
+    '''
+    queryset = TeamMember.objects.all()
+    permission_classes = [IsAuthenticated]
+
+    def perform_destroy(self, instance):
+        if instance.is_leader:
+            # 만약 Leader인 경우, 다음 index의 유저를 Leader로 설정
+            next_leader = instance.team.member.filter(is_leader=False).first()
+            if next_leader:
+                next_leader.is_leader = True
+                next_leader.save()
+        instance.delete()
+        return Response({"detail": "모임 탈퇴 완료되었습니다."}, status=status.HTTP_204_NO_CONTENT)
+    
+
+class TeamKickView(generics.DestroyAPIView):
+    '''
+    모임의 구성원 추방을 위한 View
+    로그인 권한, 리더 권한 필요
+    request body : user_id (추방 대상의 user_id)
+    '''
+    queryset = TeamMember.objects.all()
+    permission_classes = [IsAuthenticated, IsLeaderOrReadOnly]
+
+    def get_object(self):
+        user_id = self.request.data.get('user_id')
+        return get_object_or_404(self.get_queryset(), user=user_id)
+
+    def perform_destroy(self, instance):
+        instance.delete()
+        return Response({'detail': '구성원 추방 완료되었습니다.'}, status=status.HTTP_204_NO_CONTENT)
+
+
+class TeamLeaderChangeView(generics.UpdateAPIView):
+    '''
+    모임의 리더를 변경하기 위한 View
+    로그인 권한, 리더 권한 필요
+    '''
+    queryset = TeamMember.objects.all()
+    serializer_class = TeamMemberChangeSerializer
+    permission_classes = [AllowAny]
+    # permission_classes = [IsAuthenticated, IsLeaderOrReadOnly]
+
+    def perform_update(self, serializer):
+        previous_leader = TeamMember.objects.get(team=self.kwargs['pk'], is_leader=True)
+        previous_leader.is_leader = False
+        previous_leader.save()
+
+        new_leader = TeamMember.objects.get(team=self.kwargs['pk'], user=self.request.data.get('user'))
+        new_leader.is_leader = True
+        new_leader.save()
+        
+        return Response({"detail": "리더 권한이 변경되었습니다."}, status=status.HTTP_200_OK)
+
+
+class TeamMembersView(generics.ListAPIView):
+    '''
+    구성원 목록을 보기 위한 View
+    로그인 권한 필요
+    '''
+    queryset = TeamMember.objects.all()
+    serializer_class = TeamMemberSerializer
+    permission_classes = [AllowAny]
+    # permission_classes = [IsAuthenticated]
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset().filter(team_id=self.kwargs['pk'])
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
## 생성 및 수정한 파일
teams 앱 일체
schedules > model 수정

## Detail
Team(모임) 모델의 URL 설계에 맞춰 API를 구현하였습니다.
일정 모델 중 Date(특정 날짜 지정) 기능을 제거하기로 해 수정하였습니다.
이로인해 기존 1:N관계였던 모임:일정 관계가 1:1관계가 되었습니다.
일정 앱에서 할 예정이었던 '일정 수정' 기능을 모임의 Detail 수정 때 같이 하도록 통합하였습니다.

## 비고
모임 정보 조회 시 일정 모델이 Join 되는 형태가 되었기 때문에 FE 작업시 응답값을 미리 확인해 둘 필요가 있을 것 같습니다.

Thunder Client와 직접 관리자 페이지에서 생성한 DB로 테스트 완료하였습니다.
다만 로그인이 구현된 페이지에서 요청을 전송해보지는 않아 아직 권한 부분이 미확인되었습니다. 내일 중 FE구현된 환경에서 로그인 후 테스트 마친 후 문제 있을 시 수정하겠습니다.