### PR TITLE
:sparkles: Feat: 모집 게시글 생성 기능 구현 및 모임 인원 수 관련 기능 구현 ( #54, #57)

### DIFF
--- a/BE/recruits/models.py
+++ b/BE/recruits/models.py
@@ -10,6 +10,19 @@ class RecruitmentPost(models.Model):
         모집 게시글 작성에 필요한 Category와 같은 정보는 외래키로 설정한 Team 모델에서 가져옵니다.
         - Category, max_attendance, current_attendance
     '''
+    REGION_CHOICES = [
+        ('지역 무관', '지역 무관'),
+        ('서울', '서울'),
+        ('경기', '경기'),
+        ('강원', '강원'),
+        ('충북', '충북'),
+        ('충북', '충남'),
+        ('전북', '전북'),
+        ('전남', '전남'),
+        ('경북', '경북'),
+        ('경남', '경남'),
+        ('제주', '제주'),
+    ]
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     author = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
     title = models.TextField()
@@ -17,6 +30,7 @@ class RecruitmentPost(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     view_count = models.IntegerField(default=0)
+    region = models.CharField(max_length=10, choices=REGION_CHOICES, default='지역 무관')
 
     def __str__(self):
         return self.title

--- a/BE/recruits/serializers.py
+++ b/BE/recruits/serializers.py
@@ -1,13 +1,22 @@
 from rest_framework import serializers
 from .models import RecruitmentPost
-from teams.models import TeamMember
+from teams.serializers import ScheduleSerializer
+
 
 class RecruitmentPostSerializer(serializers.ModelSerializer):
     class Meta:
         model = RecruitmentPost
-        fields = ['id', 'team', 'author', 'title', 'content', 'created_at', 'updated_at', 'view_count']
+        fields = ['id', 'team', 'author', 'title', 'content', 'region', 'created_at', 'updated_at', 'view_count']
 
-class TeamMemberSerializer(serializers.ModelSerializer):
+
+class RecruitmentPostCreateSerializer(serializers.ModelSerializer):
+    frequency = serializers.CharField(source='team.schedule.frequency')
+    week = serializers.ListField(child=serializers.CharField(), source='team.schedule.week')
+    day = serializers.ListField(child=serializers.CharField(), source='team.schedule.day')
+
+    category = serializers.CharField(source='team.category')
+    max_attendance = serializers.IntegerField(source='team.max_attendance')
+
     class Meta:
-        model = TeamMember
-        fields = ['user', 'team', 'is_leader', 'is_approved']
+        model = RecruitmentPost
+        fields = ['id', 'team', 'author', 'title', 'content', 'region', 'created_at', 'updated_at', 'view_count', 'frequency', 'week', 'day', 'category', 'max_attendance']

--- a/BE/recruits/views.py
+++ b/BE/recruits/views.py
@@ -3,9 +3,9 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from .models import RecruitmentPost
-from .serializers import RecruitmentPostSerializer, TeamMemberSerializer
+from .serializers import RecruitmentPostSerializer, RecruitmentPostCreateSerializer
 from teams.models import Team, TeamMember
-from teams.serializers import TeamSerializer, ScheduleSerializer
+from teams.serializers import TeamSerializer, ScheduleSerializer, TeamMemberSerializer
 from schedules.models import Schedule
 
 class RecruitmentPostViewSet(viewsets.ModelViewSet):
@@ -31,7 +31,50 @@ class RecruitmentPostViewSet(viewsets.ModelViewSet):
         '''
         게시글 생성 시 Team과 Schedule 생성
         '''
-        pass
+        serializer = RecruitmentPostCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        
+        # 모임 정보가 입력되어 있지 않을 경우 모임 생성
+        if not serializer.validated_data['team']:
+            user = serializer.validated_data['user']
+            team_data = {
+                'name': f"{user.nickname}의 모임",
+                'category': serializer.validated_data['category'],
+                'max_attendance': serializer.validated_data['max_attendance'],
+                'current_attendance': 1,
+            }
+            team_serializer = TeamSerializer(data=team_data)
+            team_serializer.is_valid(raise_exception=True)
+            team_serializer.save()
+
+            # 작성자 모임 리더 등록
+            team_member_data = {
+                'user': user.id,
+                'team': team_serializer.data['id'],
+                'is_leader': True,
+                'is_approved': True,
+            }
+            team_member_serializer = TeamMemberSerializer(data=team_member_data)
+            team_member_serializer.is_valid(raise_exception=True)
+            team_member_serializer.save()
+            serializer.validated_data['team'] = team_serializer.data['id']
+
+        # 모집 게시물 생성
+        self.perform_create(serializer)
+
+        # 일정 생성
+        schedule_data = {
+            'team': serializer.validated_data['team'],
+            'frequency': serializer.validated_data['frequency'],
+            'week': serializer.validated_data['week'],
+            'day': serializer.validated_data['day']
+        }
+        schedule_serializer = ScheduleSerializer(data=schedule_data)
+        schedule_serializer.is_valid(raise_exception=True)
+        schedule_serializer.save()
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
     
     @action(detail=False, methods=['get'], url_path='hot', url_name='hot')
     def hot_list(self, request):
@@ -39,6 +82,8 @@ class RecruitmentPostViewSet(viewsets.ModelViewSet):
         인기 모집목록 조회 기능
         정렬 기준 : view_count
         모집 개수 : count 변수
+
+        페이지네이션 적용 필요
         '''
         count = 5
         queryset = RecruitmentPost.objects.order_by('-view_count')[:count]

--- a/BE/teams/serializers.py
+++ b/BE/teams/serializers.py
@@ -26,7 +26,8 @@ class TeamMemberSerializer(serializers.ModelSerializer):
 class TeamMemberChangeSerializer(serializers.ModelSerializer):
     class Meta:
         model = TeamMember
-        fields = ['team', 'user', 'is_leader']
+        fields = ['user', 'team', 'is_leader', 'is_approved']
+        # fields = ['user', 'team', 'is_leader']
 
 class ScheduleSerializer(serializers.ModelSerializer):
     day = serializers.ListField(child=serializers.CharField(), allow_empty=True)


### PR DESCRIPTION
# 수정한 파일
teams > serializers.py
teams > views.py
recruits > models.py
recruits > serializers.py
recruits > views.py

## 수정한 내용
teams 앱의 구성원 승인, 추방, 탈퇴 요청 시 current_attendance 수정 기능 적용 recruits 앱의 모집 게시글 생성 기능 -> 모임, 일정 생성 연동
recruits model에 'region(지역)' 필드가 빠져있어 추가

## 비고
테스트를 아직 진행하지 못했습니다.
오전 중 테스트 후 문제가 생기면 바로 수정하겠습니다.