### PR TITLE
:bug: Fix : LOGIR_URL 명시

### DIFF
--- a/BE/gluv/settings.py
+++ b/BE/gluv/settings.py
@@ -187,3 +187,5 @@ SPECTACULAR_SETTINGS = {
         'persistAuthorization': True,
     },
 }
+
+LOGIN_URL = ''


### PR DESCRIPTION
저희 유저가 로그인 시 TokenObtainPairView를 사용합니다. 로그인 시 리다이렉트될 url을 명시하지 않아 FE에서 테스트 할 시에 자꾸 accounts/가 url 맨 앞에 섞이는 이슈가 있었습니다. 일단 비어둔 채로 명시해두어 메인 페이지로 옮기겠습니다.