### PR TITLE
:bug: Fix: comment 앱 API 수정

### DIFF
--- a/BE/comments/models.py
+++ b/BE/comments/models.py
@@ -9,7 +9,9 @@ class Comment(models.Model):
     post_id = models.ForeignKey(CommunityPost, on_delete=models.CASCADE, null=True, blank=True)
     content = models.TextField(max_length=100)
     to_user = models.ForeignKey('self', on_delete=models.CASCADE, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
     
     def __str__(self):
-        return f"Comment by {self.user}: {self.content}"
+        return f"Comment by {self.user_id}: {self.content}"
 

--- a/BE/comments/permissions.py
+++ b/BE/comments/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework import permissions
+from django.shortcuts import get_object_or_404
+from .models import Comment
+
+class IsOwner(permissions.BasePermission):
+    def has_permission(self, request, view):
+        comment_id = view.kwargs.get('pk')
+        comment = get_object_or_404(Comment, id=comment_id)
+        return comment.user_id == request.user or request.user.is_staff
+
+    def has_object_permission(self, request, view, obj):
+        return obj.user == request.user or request.user.is_staff

--- a/BE/comments/serializers.py
+++ b/BE/comments/serializers.py
@@ -4,52 +4,9 @@ from .models import Comment
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
-        fields = ('user_id', 'recruit_id', 'post_id', 'content', 'to_user')
+        fields = ('user_id', 'recruit_id', 'post_id', 'content', 'to_user', 'created_at', 'updated_at')
 
 class CommentCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
-        fields = ('content', 'post_id', 'recruit_id')
-
-    def validate(self, data):
-        recruit_id = data.get('recruit_id')
-        post_id = data.get('post_id')
-
-        if not recruit_id and not post_id:
-            raise serializers.ValidationError("ValidationError: recruit_id와 post_id 중 적어도 하나는 필요합니다.")
-
-        # 유저는 현재 로그인한 사용자로 설정
-        data['user_id'] = self.context['request'].user
-
-        return data
-
-class CommentUpdateSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Comment
-        fields = ['content']
-
-    def validate(self, data):
-        user = self.context['request'].user
-        comment = self.instance
-
-        if comment.user_id != user:
-            raise serializers.ValidationError("댓글 작성자만 댓글을 수정할 수 있습니다.")
-
-        return data
-
-class CommentDeleteSerializer(serializers.Serializer):
-    comment_id = serializers.IntegerField()
-
-    def validate(self, data):
-        comment_id = data.get('comment_id')
-        user = self.context['request'].user
-
-        try:
-            comment = Comment.objects.get(pk=comment_id)
-        except Comment.DoesNotExist:
-            raise serializers.ValidationError("해당하는 댓글이 존재하지 않습니다.")
-
-        if comment.user_id != user:
-            raise serializers.ValidationError("댓글 작성자만 댓글을 삭제할 수 있습니다.")
-
-        return data
+        fields = ('content', 'post_id', 'recruit_id', 'to_user')

--- a/BE/likes/views.py
+++ b/BE/likes/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
@@ -25,7 +25,11 @@ class LikeViewSet(viewsets.ViewSet):
     - 해당 게시물에 좋아요를 얼마나 했는지 확인:
       - URL: GET /likes/like_count/?post_id=1 또는 GET /likes/like_count/?recruit_id=1
     '''
-
+    permission_classes = [permissions.IsAuthenticated]
+    def get_permissions(self):
+        if self.action == 'like_count':
+            return [permissions.AllowAny()]
+        return super().get_permissions()
     # 좋아요 누르기
     @action(detail=False, methods=['post'])
     def like_post(self, request):

--- a/BE/recruits/views.py
+++ b/BE/recruits/views.py
@@ -41,9 +41,16 @@ class RecruitmentPostViewSet(viewsets.ModelViewSet):
     '''
     queryset = RecruitmentPost.objects.all()
     serializer_class = RecruitmentPostSerializer
-    permission_classes = [permissions.AllowAny]
+    permission_classes = [permissions.IsAuthenticated]
     pagination_class = PageNumberPagination
 
+    def get_permissions(self):
+        if self.action in ['list', 'retrieve', 'hot_list']:
+            return [permissions.AllowAny()]
+        elif self.action in ['create', 'apply']:
+            return [permissions.IsAuthenticated()]
+        return super().get_permissions()
+    
     def list(self, request, *args, **kwargs):
         search_query = request.GET.get('search', '')
         category_query = request.GET.get('category', '')
@@ -144,8 +151,6 @@ class RecruitmentPostViewSet(viewsets.ModelViewSet):
         인기 모집목록 조회 기능
         정렬 기준 : view_count
         모집 개수 : count 변수
-
-        페이지네이션 적용 필요
         '''
         count = 5
         queryset = RecruitmentPost.objects.order_by('-view_count')[:count]


### PR DESCRIPTION
## 수정한 원인
댓글 생성, 수정, 삭제 모두 request data에 user_id를 필수로 요구하는 상태였습니다. list의 페이지네이션 기능이 적용되어 있지 않았습니다.

## 비고
시리얼라이저를 다루는게 아직 미숙해 원 코드의 형태를 거의 살리지 못했습니다. 죄송합니다. 권한 설정을 하던 중 오류를 발견해 likes, recruits 앱의 설정도 수정하였습니다.