### PR TITLE
:sparkles: 유저 비밀번호 검증 구현 ( #89 )

### DIFF
--- a/BE/chatroom_messages/models.py
+++ b/BE/chatroom_messages/models.py
@@ -3,10 +3,13 @@ from django.contrib.auth import get_user_model
 
 from chatrooms.models import ChatRoom
 
+User = get_user_model()
+
+
 class ChatRoomMessage(models.Model):
     content = models.TextField()
     chatroom = models.ForeignKey(ChatRoom, on_delete=models.CASCADE)
-    user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
 
     def __str__(self):
         return f"{self.content}"

--- a/BE/recruits/views.py
+++ b/BE/recruits/views.py
@@ -6,12 +6,12 @@ from rest_framework.pagination import PageNumberPagination
 from drf_spectacular.utils import extend_schema_view, extend_schema, OpenApiParameter
 from django.db import transaction
 
-from .models import RecruitmentPost
-from .serializers import RecruitmentPostSerializer, RecruitmentPostCreateSerializer
 from teams.serializers import TeamSerializer, TeamMemberSerializer
 from teams.models import Team, TeamMember
 from schedules.models import Schedule
 
+from .models import RecruitmentPost
+from .serializers import RecruitmentPostSerializer, RecruitmentPostCreateSerializer
 
 class RecruitmentPostPagination(PageNumberPagination):
     page_size = 5

--- a/BE/users/serializers.py
+++ b/BE/users/serializers.py
@@ -22,3 +22,8 @@ class UserEditSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('region', 'nickname', 'profile_image', 'profile_content')
+
+class UserVerifySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('password')

--- a/BE/users/urls.py
+++ b/BE/users/urls.py
@@ -13,6 +13,7 @@ from .views import (
     UserProfileEditView,
     UserDeactivateView,
     UserLogoutView,
+    UserVerifyView,
 )
 
 urlpatterns = [
@@ -22,5 +23,6 @@ urlpatterns = [
     path('<int:pk>/profile/', UserDetailView.as_view(), name='user_detail'),
     path('profile/', UserProfileEditView.as_view(), name='user_profile_edit'),
     path('deactivate/', UserDeactivateView.as_view(), name='user_deactivate'),
+    path('verify/', UserVerifyView.as_view(), name='user_verify')
 ]
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## 수정한 파일
users > serializers, urls, views

## 비고
chatroom_messages의 유저모델,
recruit > views.py의 import 순서도 수정되어 있어 같이 커밋합니다.