### PR TITLE
:sparkles: Feat: 가입한 모임 리스트 반환 시 페이지네이션 적용

### DIFF
--- a/BE/teams/views.py
+++ b/BE/teams/views.py
@@ -1,12 +1,32 @@
+from rest_framework import status, generics
 from rest_framework.generics import get_object_or_404
-from rest_framework import generics
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework import status
+
 from .models import Team, TeamMember
 from .serializers import TeamSerializer, TeamMemberSerializer, TeamDetailSerializer, TeamMemberChangeSerializer
 from .permissions import IsLeaderOrReadOnly
 
+
+class TeamPagination(PageNumberPagination):
+    '''
+    Pagination 커스텀
+    '''
+    page_size = 5
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
+    def get_paginated_response(self, status, message, data):
+        return Response({
+            'status': 'success',
+            'message': 'Success message',
+            'count': self.page.paginator.count,
+            'next': self.get_next_link(),
+            'previous': self.get_previous_link(),
+            'results': data
+        })
+    
 
 class TeamListView(generics.ListAPIView):
     '''
@@ -168,6 +188,10 @@ class TeamMembersView(generics.ListAPIView):
         return Response(serializer.data)
     
 class TeamMyListView(generics.ListAPIView):
+    '''
+    유저가 가입한 모임을 보기 위한 View
+    로그인 권한 필요
+    '''
     serializer_class = TeamSerializer
     permission_classes = [IsAuthenticated]
 
@@ -176,5 +200,11 @@ class TeamMyListView(generics.ListAPIView):
         queryset = TeamMember.objects.filter(user=user_id, is_approved=True)
         team_ids = queryset.values_list('team_id', flat=True)
         teams = Team.objects.filter(id__in=team_ids)
-
         return teams
+    
+    def list(self, request, *args, **kwargs):
+        paginator = TeamPagination()
+        comments = self.get_queryset().order_by('id')
+        page = paginator.paginate_queryset(comments, request)
+        serializer = TeamSerializer(page, many=True)
+        return paginator.get_paginated_response(status='success', message='Successfully', data=serializer.data)


### PR DESCRIPTION
## 수정한 파일
teams > views.py

## 수정한 내용
전체 목록을 받아오던 '가입한 모임 리스트'를 페이지네이션을 적용해 5개씩 끊을 수 있도록 했습니다.