### PR TITLE
🐛  Fix: 모집 게시글 반환 개수 6개로 증가

### DIFF
--- a/BE/recruits/views.py
+++ b/BE/recruits/views.py
@@ -14,7 +14,7 @@ from .models import RecruitmentPost
 from .serializers import RecruitmentPostSerializer, RecruitmentPostCreateSerializer
 
 class RecruitmentPostPagination(PageNumberPagination):
-    page_size = 5
+    page_size = 6
     page_size_query_param = 'page_size'
     max_page_size = 100
 


### PR DESCRIPTION
## 수정된 파일
recruits > views.py

## 수정한 원인
FE에서 짝수개로 표현하기 때문에 5개일 경우 카드 하나가 길게 늘어납니다.
짝수로 맞춰주기 위해 6개로 늘렸습니다.