### PR TITLE
:bug: Fix: 알라딘 API에서 받아오는 book_image 해상도 증가

### DIFF
--- a/BE/books/tasks.py
+++ b/BE/books/tasks.py
@@ -23,6 +23,9 @@ def fetch_recent_book():
         published_date = book_data.get('pubDate', '')
         content = book_data.get('description', None)
 
+        if book_image and ('coversum' in book_image):
+            book_image = book_image.replace('coversum', 'cover500')
+
         _, created = Book.objects.get_or_create(
             title=title,
             defaults={


### PR DESCRIPTION
## 수정한 파일
BE\books\tasks.py

## 수정한 내용
기존에 받아오던 이미지 링크의 경우 해상도가 낮은 이미지입니다.
링크의 내용중 'coversum'을 'cover500'으로 바꾸면 해상도가 높은 이미지로 바뀌는 것을 알게되어 코드에 우선 적용합니다.

book_image가 있을 때, coversum이 들어있을 때로 조건을 설정하였습니다.